### PR TITLE
Support attributing mangled types to symbol kinds

### DIFF
--- a/Sources/SwiftDemangle/Demangler/String+Demangling.swift
+++ b/Sources/SwiftDemangle/Demangler/String+Demangling.swift
@@ -31,5 +31,11 @@ public extension String {
             }
         })
     }
-    
+
+    var symbolKind: Node.Kind? {
+        guard let node = demangleSymbolAsNode(printDebugInformation: false) else {
+            return nil
+        }
+        return node.extractSymbolKind()
+    }
 }

--- a/Sources/SwiftDemangle/Node/FunctionSigSpecializationParamKind.swift
+++ b/Sources/SwiftDemangle/Node/FunctionSigSpecializationParamKind.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct FunctionSigSpecializationParamKind: Equatable {
+public struct FunctionSigSpecializationParamKind: Equatable {
     
     public let rawValue: UInt
     

--- a/Sources/SwiftDemangle/Node/MangledDifferentiabilityKind.swift
+++ b/Sources/SwiftDemangle/Node/MangledDifferentiabilityKind.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum MangledDifferentiabilityKind: String {
+public enum MangledDifferentiabilityKind: String {
     case nonDifferentiable = ""
     case forward = "f"
     case reverse = "r"

--- a/Sources/SwiftDemangle/Node/Node.swift
+++ b/Sources/SwiftDemangle/Node/Node.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-final class Node {
-    
+public final class Node {
+
     typealias IndexType = UInt64
     
     private weak var parent: Node?
@@ -822,6 +822,27 @@ extension Node {
         }
         return nil
     }
+
+    func extractSymbolKind() -> Kind? {
+        switch kind {
+        case .Global:
+            // Global nodes wrap the actual kind as first child
+            // Skip function attributes to get to the real symbol kind
+            for child in copyOfChildren where !child.kind.isFunctionAttr {
+                return child.kind
+            }
+            return nil
+        case .TypeMangling:
+            // Type manglings wrap the actual type
+            return firstChild.extractSymbolKind()
+        case .Type:
+            // Type nodes wrap the actual kind
+            return firstChild.extractSymbolKind()
+        default:
+            // For all other cases, the current kind is the symbol kind
+            return kind
+        }
+    }
 }
 
 extension Node {
@@ -874,7 +895,7 @@ extension Node {
         }
     }
     
-    public enum Kind: String, Equatable {//}, CustomStringConvertible, CustomDebugStringConvertible {
+    public enum Kind: String, Equatable, Sendable {//}, CustomStringConvertible, CustomDebugStringConvertible {
         case Allocator
         case AnonymousContext
         case AnyProtocolConformanceList

--- a/Tests/SwiftDemangleTests/SymbolKindTests.swift
+++ b/Tests/SwiftDemangleTests/SymbolKindTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import SwiftDemangle
+
+@MainActor
+final class SymbolKindTests {
+    @Test
+    func testConstructorKind() {
+        let mangled = "_$s6Widget0A12KitExtensionVACycfc"
+        #expect(mangled.symbolKind == .Constructor)
+    }
+
+    @Test
+    func testFunctionKind() {
+        let mangled = "$s6Widget9operationyyF"
+        #expect(mangled.symbolKind == .Function)
+    }
+
+    @Test
+    func testGlobalUnwrapping() {
+        // Global symbols should unwrap to inner kind
+        let mangled = "$sSo18NSNotificationNameaSYSCSY8rawValuexSg03RawD0Qz_tcfCTWTm"
+        #expect(mangled.symbolKind != nil)
+        #expect(mangled.symbolKind != .Global)
+    }
+
+    @Test
+    func testNonSwiftSymbol() {
+        let mangled = "__mh_execute_header"
+        #expect(mangled.symbolKind == nil)
+    }
+
+    @Test
+    func testClassKind() {
+        let mangled = "$s6Widget7ManagerC"
+        #expect(mangled.symbolKind == .Class)
+    }
+
+    @Test
+    func testProtocolKind() {
+        let mangled = "$s7SwiftUI4ViewP"
+        #expect(mangled.symbolKind == .Protocol)
+    }
+}


### PR DESCRIPTION
Extends the public API to expose the symbol kind from a mangled name. This enables grouping symbols by kind, allowing for better aggregation of analytical data.